### PR TITLE
Updated missionConfig for HoundELINT update compatibility and adjusted presets for WW2 Axis aircrafts

### DIFF
--- a/src/radio/radioSettings.lua
+++ b/src/radio/radioSettings.lua
@@ -165,7 +165,7 @@ radioPresetsRed =
 radioPresetsWarbirdBlue = {
     --Axis
     ["##RADIO_FuG16_01##"] = 39.000,
-    ["##RADIO_FuG16_02##"] = 40.000,
+    ["##RADIO_FuG16_02##"] = 38.400,
     ["##RADIO_FuG16_03##"] = 41.000,
     ["##RADIO_FuG16_04##"] = 42.000,
     ["##RADIO_FuG16_BASE##"] = 38.400,
@@ -174,7 +174,7 @@ radioPresetsWarbirdBlue = {
 radioPresetsWarbirdRed = {
     --Axis
     ["##RADIO_FuG16_01##"] = 39.000,
-    ["##RADIO_FuG16_02##"] = 40.000,
+    ["##RADIO_FuG16_02##"] = 38.400,
     ["##RADIO_FuG16_03##"] = 41.000,
     ["##RADIO_FuG16_04##"] = 42.000,
     ["##RADIO_FuG16_BASE##"] = 38.400,

--- a/src/scripts/missionConfig.lua-template
+++ b/src/scripts/missionConfig.lua-template
@@ -363,25 +363,91 @@ if veafHoundElint and false then -- don't use Hound Elint
     veafHoundElint.initialize(
         "ELINT", -- prefix
         { -- red
-            admin = false,
+            --global parameters
+            sectors = {},
             markers = true,
-            atis = false,
-            controller = false
+            disableBDA = false, --disables notifications that a radar has dropped off scope
+            platformPositionErrors = true,
+            NATOmessages = false, --provides positions relative to the bullseye
+            NATO_SectorCallsigns = false, --uses a different pool for sector callsigns
+            ATISinterval = 180,
+            preBriefedContacts = {
+                --"Stuff",
+                --"Thing",
+            }, --contains the name of units placed in the ME which will be designated as pre-briefed (exact location) and who's position will be indicated exactly by Hound until the unit moved 100m away
+            debug = false, --set this to true to make sure your configuration is correct and working as intended
         },
         { -- blue
-            admin = false,
-            markers = true,
-            atis = {
-                freq = 282.125,
-                interval = 15,
-                speed = 1,
-                reportEWR = false
+            sectors = {
+                --Global sector, mandatory inclusion if you want a global ATIS/controller etc., encompasses the whole map so it'll be very crowded in terms of comms
+                [veafHoundElint.globalSectorName] = {
+                    callsign = "Global Sector", --defines a specific callsign for the sector which will be used by the ATIS etc., if absent or nil Hound will assign it a callsign automatically, NATO format of regular Hound format. If true, callsign will be equal to the sector name
+                    atis = {
+                        freq = 282.175,
+                        speed = 1,
+                        --additional params
+                        reportEWR = false
+                    },
+                    controller = {
+                        freq = 282.225,
+                        --additional params
+                        voiceEnabled = true
+                    },
+                    notifier = {
+                        freq = 282.2,
+                        --additional params
+                    },
+                    disableAlerts = false, --disables alerts on the ATIS/Controller when a new radar is detected or destroyed
+                    transmitterUnit = nil, --use the Unit/Pilot name to set who the transmitter is for the ATIS etc. This can be a static, and aircraft or a vehicule/ship
+                    disableTTS = false,
+                },
+                --sector named "Maykop", will be geofenced to the mission editor drawing called "Maykop" (case sensitive)
+                ["Maykop"] = {
+                    callsign = true, --defines a specific callsign for the sector which will be used by the ATIS etc., if absent or nil Hound will assign it a callsign automatically, NATO format of regular Hound format. If true, callsign will be equal to the sector name
+                    atis = {
+                        freq = 281.075,
+                        speed = 1,
+                        --additional params
+                        reportEWR = false
+                    },
+                    controller = {
+                        freq = 281.125,
+                        --additional params
+                        voiceEnabled = true
+                    },
+                    notifier = {
+                        freq = 281.1,
+                        --additional params
+                    },
+                    disableAlerts = false, --disables alerts on the ATIS/Controller when a new radar is detected or destroyed
+                    transmitterUnit = nil, --use the Unit/Pilot name to set who the transmitter is for the ATIS etc. This can be a static, and aircraft or a vehicule/ship
+                    disableTTS = false,
+                },
             },
-            controller = {
-                freq = 282.225,
-                voiceEnabled = true
-            }
+            --global parameters
+            markers = true,
+            disableBDA = false, --disables notifications that a radar has dropped off scope
+            platformPositionErrors = true,
+            NATOmessages= true, --provides positions relative to the bullseye
+            NATO_SectorCallsigns = true, --uses a different pool for sector callsigns
+            ATISinterval = 180,
+            preBriefedContacts = {
+                --"Stuff",
+                --"Thing",
+            }, --contains the name of units or groups placed in the ME which will be designated as pre-briefed (exact location) and who's position will be indicated exactly by Hound until the unit moved 100m away. If multiple radars are within a specified group, they'll all be added as pre-briefed targets
+            debug = false, --set this to true to make sure your configuration is correct and working as intended
         }
+        -- args = {
+        --     freq = 250.000,
+        --     modulation = "AM",
+        --     volume = "1.0",
+        --     speed = <speed> -- number default is 0/1 for controller/atis. range is -10 to +10 on windows TTS. for google it's 0.25 to 4.0
+        --     gender = "male"|"female",
+        --     culture = "en-US"|"en-UK" -- (any installed on your system)
+        --     isGoogle = true/false -- use google TTS (requires additional STTS config)
+        --     voiceEnabled = true/false (for the controller only) -- to set if the controllers uses text or TTS
+        --     reportEWR = true/false (for ATIS only) -- set to tell the ATIS to report EWRs as threats
+        -- }
     )
 end
 


### PR DESCRIPTION
Note for the preset adjustement, this was made as one of the channels for the Fw190 (A8 and D9 I suspect) is not editable. All Axis aircrafts should remain consistent with this change.